### PR TITLE
Fix regression failure related to FLEXIBLE_ARRAY_MEMBER changes

### DIFF
--- a/plv8_param.cc
+++ b/plv8_param.cc
@@ -181,8 +181,8 @@ plv8_setup_variable_paramlist(plv8_param_state *parstate,
 {
 	ParamListInfo		paramLI;
 
-	paramLI = (ParamListInfo) palloc0(sizeof(ParamListInfoData) +
-							sizeof(ParamExternData) * (parstate->numParams - 1));
+	paramLI = (ParamListInfo) palloc0(offsetof(ParamListInfoData, params) +
+							sizeof(ParamExternData) * parstate->numParams);
 	paramLI->numParams = parstate->numParams;
 	for(int i = 0; i < parstate->numParams; i++)
 	{


### PR DESCRIPTION
When building the code on at least Postgres master at 09d8d11 (oops),
regression tests are failing in multiple places because of an incorrect
calculation the allocation size used for ParamListInfoData that is now using
FLEXIBLE_ARRAY_MEMBER. Here is an example of failure:
+ WARNING: problem in alloc set SPI Proc: detected write past chunk end in
block 0xdc1ff0, chunk 0xdc2098

Attached is a patch fixing the problem by using offsetof() instead of sizeof()
in plv8_setup_variable_paramlist. Note that this solution is compatible with
~9.4 and I think that this way the allocation calculation is more correct.