### PR TITLE
Support for recent (4.1.0.x) V8 version

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,11 @@
 Revision history for plv8
 
+x.x.x       2015-02-21
+            - Adaptions for current V8 version, e.g. 4.1.0.x
+	      (see http://strongloop.com/strongblog/node-js-v0-12-c-apis-breaking/
+	      for an overview of the V8 changes which break existing code bases)
+	    - GUC plv8.v8_flags for V8 engine initialization flags
+
 1.4.3       2015-02-02
             - Fix compilation for 9.4
             - Fix off-by-one in variadic .execute handling

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Makefile for plv8
 #
 # @param DISABLE_DIALECT if defined, not build dialects (i.e. plcoffee, etc)
-# @param ENABLE_DEBUGGER_SUPPORT enables v8 deubbger agent
+# @param ENABLE_DEBUGGER_SUPPORT enables v8 debugger agent
 #
 # There are two ways to build plv8.
 # 1. Dynamic link to v8 (default)
@@ -37,7 +37,7 @@ DATA += plcoffee.control plcoffee--$(PLV8_VERSION).sql \
 endif
 DATA_built = plv8.sql
 REGRESS = init-extension plv8 inline json startup_pre startup varparam json_conv \
-		  jsonb_conv window
+		  jsonb_conv window guc es6
 ifndef DISABLE_DIALECT
 REGRESS += dialect
 endif
@@ -52,11 +52,16 @@ endif
 ifdef ENABLE_DEBUGGER_SUPPORT
 OPT_ENABLE_DEBUGGER_SUPPORT = -DENABLE_DEBUGGER_SUPPORT
 endif
-OPTFLAGS = -O2 -DV8_USE_UNSAFE_HANDLES
+
+# for older g++ (e.g. 4.6.x), which do not support c++11
+#OPTFLAGS = -O2 -std=gnu++0x -fno-rtti
+
+OPTFLAGS = -O2 -std=c++11 -fno-rtti
+
 CCFLAGS = -Wall $(OPTFLAGS) $(OPT_ENABLE_DEBUGGER_SUPPORT)
 
 ifdef V8_SRCDIR
-override CPPFLAGS += -I$(V8_SRCDIR)/include
+override CPPFLAGS += -I$(V8_SRCDIR) -I$(V8_SRCDIR)/include
 endif
 
 all:

--- a/Makefile.v8
+++ b/Makefile.v8
@@ -7,11 +7,14 @@
 # structure in v8 which may be different from version to another, but user
 # can specify the v8 version by AUTOV8_VERSION, too.
 #-----------------------------------------------------------------------------#
-AUTOV8_VERSION = 3.14.5
-AUTOV8_DIR = build/v8-$(AUTOV8_VERSION)
-AUTOV8_OUT = build/v8-$(AUTOV8_VERSION)/out/native
+AUTOV8_VERSION = 4.3.66
+AUTOV8_DIR = build/v8-git-mirror-$(AUTOV8_VERSION)
+AUTOV8_OUT = build/v8-git-mirror-$(AUTOV8_VERSION)/out/native
+AUTOV8_DEPOT_TOOLS = build/depot_tools
 AUTOV8_LIB = $(AUTOV8_OUT)/libv8_snapshot.a
-AUTOV8_STATIC_LIBS = libv8_base.a libv8_snapshot.a
+AUTOV8_STATIC_LIBS = libv8_base.a libv8_snapshot.a libv8_libplatform.a libv8_libbase.a libicui18n.a libicuuc.a libicudata.a
+
+export PATH := $(abspath $(AUTOV8_DEPOT_TOOLS)):$(PATH)
 
 SHLIB_LINK += $(addprefix $(AUTOV8_OUT)/, $(AUTOV8_STATIC_LIBS))
 
@@ -20,23 +23,40 @@ all: $(AUTOV8_LIB)
 # For some reason, this solves parallel make dependency.
 plv8_config.h: $(AUTOV8_LIB)
 
-$(AUTOV8_DIR):
+$(AUTOV8_DEPOT_TOOLS):
 	mkdir -p build
-	curl -L 'https://github.com/v8/v8/archive/$(AUTOV8_VERSION).tar.gz' \
-		| tar zxf - -C build
+	cd build; git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+
+$(AUTOV8_DIR): $(AUTOV8_DEPOT_TOOLS)
+	cd build; fetch v8; cd v8; git checkout $(AUTOV8_VERSION); gclient sync
+	mv build/v8 $(AUTOV8_DIR)
 
 $(AUTOV8_LIB): $(AUTOV8_DIR)
-	env CXXFLAGS=-fPIC $(MAKE) -C build/v8-$(AUTOV8_VERSION) dependencies
-	env CXXFLAGS=-fPIC $(MAKE) -C build/v8-$(AUTOV8_VERSION) native
+	env CXXFLAGS=-fPIC CFLAGS=-fPIC $(MAKE) -C build/v8-git-mirror-$(AUTOV8_VERSION) native
 	test -f $(AUTOV8_OUT)/libv8_base.a || \
 		ln -s $(abspath $(AUTOV8_OUT)/obj.target/tools/gyp/libv8_base.a) \
 			$(AUTOV8_OUT)/libv8_base.a
 	test -f $(AUTOV8_OUT)/libv8_snapshot.a || \
 		ln -s $(abspath $(AUTOV8_OUT)/obj.target/tools/gyp/libv8_snapshot.a) \
 			$(AUTOV8_OUT)/libv8_snapshot.a
+	test -f $(AUTOV8_OUT)/libv8_libbase.a || \
+		ln -s $(abspath $(AUTOV8_OUT)/obj.target/tools/gyp/libv8_libbase.a) \
+			$(AUTOV8_OUT)/libv8_libbase.a
+	test -f $(AUTOV8_OUT)/libv8_libplatform.a || \
+		ln -s $(abspath $(AUTOV8_OUT)/obj.target/tools/gyp/libv8_libplatform.a) \
+			$(AUTOV8_OUT)/libv8_libplatform.a
+	test -f $(AUTOV8_OUT)/libicui18n.a || \
+		ln -s $(abspath $(AUTOV8_OUT)/obj.target/third_party/icu/libicui18n.a) \
+			$(AUTOV8_OUT)/libicui18n.a
+	test -f $(AUTOV8_OUT)/libicuuc.a || \
+		ln -s $(abspath $(AUTOV8_OUT)/obj.target/third_party/icu/libicuuc.a) \
+			$(AUTOV8_OUT)/libicuuc.a
+	test -f $(AUTOV8_OUT)/libicudata.a || \
+		ln -s $(abspath $(AUTOV8_OUT)/obj.target/third_party/icu/libicudata.a) \
+			$(AUTOV8_OUT)/libicudata.a
 
 include Makefile
 
-CCFLAGS += -I$(AUTOV8_DIR)/include
+CCFLAGS += -I$(AUTOV8_DIR)/include -I$(AUTOV8_DIR)
 # We're gonna build static link.  Rip it out after include Makefile
 SHLIB_LINK := $(filter-out -lv8, $(SHLIB_LINK))

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ REQUIREMENT
 
 plv8 is tested with:
 
-- PG: version 8.4, 9.0, 9.1, 9.2 and 9.3dev (maybe older are allowed)
-- V8: version 3.14.5
-- g++: version 4.5.1
+- PG: version 9.4 (maybe older are allowed)
+- V8: version 4.3.66
+- g++: version 4.8.2
 
 It is also known to work with some older versions of gcc and v8.
 

--- a/doc/plv8.md
+++ b/doc/plv8.md
@@ -413,6 +413,22 @@ and return the value.  An example for these types are as follows.
         15
   (1 row)
 
+ES6 Language Features
+---------------------
+
+PL/v8 enables all shipping feature of the used V8 version. So with V8 4.1+
+many ES6 features, like block scoping, collections, generators and string
+templates, are enabled by default.
+
+Additional features can be enabled by setting the GUC plv8.v8_flags
+(e.g. "SET plv8.v8_flags = '--es_staging';").
+
+These flags are honoured once per user session when the V8 runtime is
+initialized. Compared to dialects (see below), which can be set on a
+per function base, the V8 flags cannot be changed once the runtime is
+initialized. So normally this setting should rather be set per database,
+and not per session.
+
 Remote debugger
 ---------------
 
@@ -471,5 +487,5 @@ are supported.
 - CoffeeScript (plcoffee)
 - LiveScript (plls)
 
-With PostgreSQL 9.1 or above, you are able to load tohse dialects via CREATE
+With PostgreSQL 9.1 or above, you are able to load those dialects via CREATE
 EXTENSION command.

--- a/expected/es6.out
+++ b/expected/es6.out
@@ -1,0 +1,64 @@
+-- ES6 / harmony features
+CREATE TABLE rectangle (
+   id    INTEGER,
+   data  JSON
+);
+INSERT INTO rectangle (id, data) VALUES
+(1, '{"width": 20.3, "height": 1.5}'),
+(2, '{"width": 10.2, "height": 9.5}'),
+(3, '{"width": 3.5,  "height": 5.2}'),
+(4, '{"width": 8.2,  "height": 8.2}'),
+(5, '{"width": 9.4,  "height": 0.2}'),
+(6, '{"width": 1.2,  "height": 1.5}');
+-- for..of loop over result array with break
+CREATE OR REPLACE FUNCTION get_rectangles_area(min_area NUMERIC)
+   RETURNS json AS $$
+      var rectangles = plv8.execute('SELECT id, data FROM rectangle ORDER BY id');
+      var result = [];
+      var area = 0.0;
+      for (var rectangle of rectangles) {
+	 area += rectangle.data.width * rectangle.data.height;
+	 result.push({id: rectangle.id, data: rectangle.data});
+	 if (area >= min_area) {
+	    break;
+	 }
+      }
+      return result;
+   $$ LANGUAGE plv8 STABLE STRICT;
+SELECT get_rectangles_area(130.0);
+                                                         get_rectangles_area                                                          
+--------------------------------------------------------------------------------------------------------------------------------------
+ [{"id":1,"data":{"width":20.3,"height":1.5}},{"id":2,"data":{"width":10.2,"height":9.5}},{"id":3,"data":{"width":3.5,"height":5.2}}]
+(1 row)
+
+-- same for..of loop, this time using a cursor within a generator
+CREATE OR REPLACE FUNCTION get_rectangles_area(min_area NUMERIC)
+   RETURNS json AS $$
+      var plan = plv8.prepare('SELECT id, data FROM rectangle ORDER BY id');
+      var cursor = plan.cursor();
+      var generator = function* () {
+	 var row;
+	 while (row = cursor.fetch()) {
+	    yield row;
+	 }
+      };
+      var rectangles = generator();
+      var result = [];
+      var area = 0.0;
+      for (var rectangle of rectangles) {
+	 area += rectangle.data.width * rectangle.data.height;
+	 result.push({id: rectangle.id, data: rectangle.data});
+	 if (area >= min_area) {
+	    break;
+	 }
+      }
+      cursor.close();
+      plan.free();
+      return result;
+   $$ LANGUAGE plv8 STABLE STRICT;
+SELECT get_rectangles_area(130.0);
+                                                         get_rectangles_area                                                          
+--------------------------------------------------------------------------------------------------------------------------------------
+ [{"id":1,"data":{"width":20.3,"height":1.5}},{"id":2,"data":{"width":10.2,"height":9.5}},{"id":3,"data":{"width":3.5,"height":5.2}}]
+(1 row)
+

--- a/expected/guc.out
+++ b/expected/guc.out
@@ -1,0 +1,14 @@
+-- enable strict mode with GUC, which allows usage of ES6 let and const keywords
+SET plv8.v8_flags = '--use_strict';
+CREATE OR REPLACE FUNCTION let_test()
+   RETURNS json AS $$
+      let result = ['Hello, World!'];
+      return result;
+   $$ LANGUAGE plv8 STABLE STRICT;
+SELECT let_test();
+     let_test      
+-------------------
+ ["Hello, World!"]
+(1 row)
+
+DROP FUNCTION let_test();

--- a/plv8.h
+++ b/plv8.h
@@ -169,13 +169,16 @@ public:
 		if (WindowObjectIsValid(m_winobj))
 		{
 			m_plv8obj = v8::Handle<v8::Object>::Cast(
-					context->Global()->Get(v8::String::NewSymbol("plv8")));
+					context->Global()->Get(v8::String::NewFromUtf8(
+						context->GetIsolate(),
+						"plv8",
+						v8::String::kInternalizedString)));
 			if (m_plv8obj.IsEmpty())
 				throw js_error("plv8 object not found");
 			/* Stash the current item, just in case of nested call */
 			m_prev_fcinfo = m_plv8obj->GetInternalField(PLV8_INTNL_FCINFO);
 			m_plv8obj->SetInternalField(PLV8_INTNL_FCINFO,
-					v8::External::New(fcinfo));
+					v8::External::New(context->GetIsolate(), fcinfo));
 		}
 	}
 	bool IsWindowCall() { return WindowObjectIsValid(m_winobj); }
@@ -206,15 +209,18 @@ public:
 			   Converter *conv, Tuplestorestate *tupstore)
 	{
 		m_plv8obj = v8::Handle<v8::Object>::Cast(
-				context->Global()->Get(v8::String::NewSymbol("plv8")));
+				context->Global()->Get(v8::String::NewFromUtf8(
+					context->GetIsolate(),
+					"plv8",
+					v8::String::kInternalizedString)));
 		if (m_plv8obj.IsEmpty())
 			throw js_error("plv8 object not found");
 		m_prev_conv = m_plv8obj->GetInternalField(PLV8_INTNL_CONV);
 		m_prev_tupstore = m_plv8obj->GetInternalField(PLV8_INTNL_TUPSTORE);
 		m_plv8obj->SetInternalField(PLV8_INTNL_CONV,
-									v8::External::New(conv));
+									v8::External::New(context->GetIsolate(), conv));
 		m_plv8obj->SetInternalField(PLV8_INTNL_TUPSTORE,
-									v8::External::New(tupstore));
+									v8::External::New(context->GetIsolate(), tupstore));
 	}
 	~SRFSupport()
 	{
@@ -224,6 +230,7 @@ public:
 	}
 };
 
+extern v8::Isolate* plv8_isolate;
 extern v8::Local<v8::Function> find_js_function(Oid fn_oid);
 extern v8::Local<v8::Function> find_js_function_by_name(const char *signature);
 extern const char *FormatSPIStatus(int status) throw();
@@ -242,7 +249,7 @@ extern char *ToCStringCopy(const v8::String::Utf8Value &value);
 
 // plv8_func.cc
 extern v8::Handle<v8::Function> CreateYieldFunction(Converter *conv, Tuplestorestate *tupstore);
-extern v8::Handle<v8::Value> Subtransaction(const v8::Arguments& args) throw();
+extern void Subtransaction(const v8::FunctionCallbackInfo<v8::Value>& info) throw();
 
 extern void SetupPlv8Functions(v8::Handle<v8::ObjectTemplate> plv8);
 

--- a/sql/es6.sql
+++ b/sql/es6.sql
@@ -1,0 +1,56 @@
+-- ES6 / harmony features
+CREATE TABLE rectangle (
+   id    INTEGER,
+   data  JSON
+);
+INSERT INTO rectangle (id, data) VALUES
+(1, '{"width": 20.3, "height": 1.5}'),
+(2, '{"width": 10.2, "height": 9.5}'),
+(3, '{"width": 3.5,  "height": 5.2}'),
+(4, '{"width": 8.2,  "height": 8.2}'),
+(5, '{"width": 9.4,  "height": 0.2}'),
+(6, '{"width": 1.2,  "height": 1.5}');
+
+-- for..of loop over result array with break
+CREATE OR REPLACE FUNCTION get_rectangles_area(min_area NUMERIC)
+   RETURNS json AS $$
+      var rectangles = plv8.execute('SELECT id, data FROM rectangle ORDER BY id');
+      var result = [];
+      var area = 0.0;
+      for (var rectangle of rectangles) {
+	 area += rectangle.data.width * rectangle.data.height;
+	 result.push({id: rectangle.id, data: rectangle.data});
+	 if (area >= min_area) {
+	    break;
+	 }
+      }
+      return result;
+   $$ LANGUAGE plv8 STABLE STRICT;
+SELECT get_rectangles_area(130.0);
+
+-- same for..of loop, this time using a cursor within a generator
+CREATE OR REPLACE FUNCTION get_rectangles_area(min_area NUMERIC)
+   RETURNS json AS $$
+      var plan = plv8.prepare('SELECT id, data FROM rectangle ORDER BY id');
+      var cursor = plan.cursor();
+      var generator = function* () {
+	 var row;
+	 while (row = cursor.fetch()) {
+	    yield row;
+	 }
+      };
+      var rectangles = generator();
+      var result = [];
+      var area = 0.0;
+      for (var rectangle of rectangles) {
+	 area += rectangle.data.width * rectangle.data.height;
+	 result.push({id: rectangle.id, data: rectangle.data});
+	 if (area >= min_area) {
+	    break;
+	 }
+      }
+      cursor.close();
+      plan.free();
+      return result;
+   $$ LANGUAGE plv8 STABLE STRICT;
+SELECT get_rectangles_area(130.0);

--- a/sql/guc.sql
+++ b/sql/guc.sql
@@ -1,0 +1,9 @@
+-- enable strict mode with GUC, which allows usage of ES6 let and const keywords
+SET plv8.v8_flags = '--use_strict';
+CREATE OR REPLACE FUNCTION let_test()
+   RETURNS json AS $$
+      let result = ['Hello, World!'];
+      return result;
+   $$ LANGUAGE plv8 STABLE STRICT;
+SELECT let_test();
+DROP FUNCTION let_test();


### PR DESCRIPTION
Recent V8 versions changed the API quite a bit. See the V8's project change notes
https://docs.google.com/document/d/1g8JFi8T_oAE_7uAri7Njtig7fKaPDfotU6huOa1alds/
or this blog post for a summary
http://strongloop.com/strongblog/node-js-v0-12-c-apis-breaking/

With the changes from this pull request plv8 builds with the 4.1.0.x V8 version. This version currently ships with chromium stable:
http://www.chromium.org/developers/calendar
Depending on the minor 4.1.0.x version the actually supported gcc versions vary. The compile flags try to compensate for this. gcc 4.8.2 on Ubuntu 14.04 is working fine here. In case of issues building V8 on older systems try falling back to an other V8 from 4.1 branch, e.g. 4.1.0.14.