### PR TITLE
Add JSONB Support

### DIFF
--- a/plv8_type.cc
+++ b/plv8_type.cc
@@ -26,6 +26,10 @@ extern "C" {
 #include "utils/syscache.h"
 #include "utils/typcache.h"
 
+#if PG_VERSION_NUM >= 90400
+#include "utils/jsonb.h"
+#endif
+
 #undef delete
 #undef namespace
 #undef typeid
@@ -300,6 +304,20 @@ ToScalarDatum(Handle<v8::Value> value, bool *isnull, plv8_type *type)
 				return PointerGetDatum(datum_p);
 			}
 		}
+#if PG_VERSION_NUM >= 90400
+	case JSONBOID:
+		if (value->IsObject() || value->IsArray())
+		{
+			JSONObject JSON;
+
+			Handle<v8::Value> result = JSON.Stringify(value);
+			CString str(result);
+
+			// lots of casting, but it ends up working - there is no CStringGetJsonb exposed
+			return (Datum) DatumGetJsonb(DirectFunctionCall1(jsonb_in, (Datum) (char *) str));
+		}
+		break;
+#endif
 #if PG_VERSION_NUM >= 90200
 	case JSONOID:
 		if (value->IsObject() || value->IsArray())
@@ -491,6 +509,22 @@ ToScalarValue(Datum datum, bool isnull, plv8_type *type)
 
 		if (p != DatumGetPointer(datum))
 			pfree(p);	// free if detoasted
+		return result;
+	}
+#endif
+#if PG_VERSION_NUM >= 90400
+	case JSONBOID:
+	{
+		Jsonb   *jb = DatumGetJsonb(datum);
+		const char *str = JsonbToCString(NULL, &jb->root, VARSIZE(jb));
+		int			len = VARSIZE_ANY_EXHDR(jb) - 4;
+
+		Local<v8::Value>	jsonString = ToString(str, len);
+		JSONObject JSON;
+		Local<v8::Value> result = Local<v8::Value>::New(JSON.Parse(jsonString));
+
+		if ((void *) jb != DatumGetPointer(datum))
+			pfree(jb);	// free if detoasted
 		return result;
 	}
 #endif


### PR DESCRIPTION
This adds `JSONB` support to PLV8 for pg versions 9.4.x and above.

Unfortunately, `CStringGetJsonb` does not currently exist in jsonb.c, so this works around it by making a direct function call via `DirectFunctionCall1`.

`CStringGetJsonb` should be added to Postgres core, at which point this implementation should be changed to use it.

