### PR TITLE
fix osx compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,17 @@ ifdef V8_SRCDIR
 override CPPFLAGS += -I$(V8_SRCDIR) -I$(V8_SRCDIR)/include
 endif
 
+ifeq ($(OS),Windows_NT)
+	# noop for now, it could come in handy later
+else
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Darwin)
+		CCFLAGS += -stdlib=libstdc++
+		SHLIB_LINK := -stdlib=libstdc++
+		SHLIB_LINK += -lv8_base -lv8_libbase -lv8_libplatform -lv8_snapshot
+	endif
+endif
+
 all:
 
 plv8_config.h: plv8_config.h.in Makefile

--- a/Makefile.v8
+++ b/Makefile.v8
@@ -60,3 +60,13 @@ include Makefile
 CCFLAGS += -I$(AUTOV8_DIR)/include -I$(AUTOV8_DIR)
 # We're gonna build static link.  Rip it out after include Makefile
 SHLIB_LINK := $(filter-out -lv8, $(SHLIB_LINK))
+
+ifeq ($(OS),Windows_NT)
+	# noop for now
+else
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Darwin)
+		CCFLAGS += -stdlib=libstdc++
+		SHLIB_LINK += -stdlib=libstdc++
+	endif
+endif


### PR DESCRIPTION
this should fix OS X compilation for both `make static` and `make` with v8 already installed.

i tested locally, and this only affects OS X for me - please test for yourself.
