### PR TITLE
Crashfix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ DATA += plcoffee.control plcoffee--$(PLV8_VERSION).sql \
 endif
 DATA_built = plv8.sql
 REGRESS = init-extension plv8 inline json startup_pre startup varparam json_conv \
-		  jsonb_conv window guc es6
+		  jsonb_conv window guc es6 arraybuffer
 ifndef DISABLE_DIALECT
 REGRESS += dialect
 endif

--- a/expected/arraybuffer.out
+++ b/expected/arraybuffer.out
@@ -6,7 +6,7 @@ AS $$
 $$;
 SELECT crash_test();
 WARNING:  Allocating: 8
- crash_test
+ crash_test 
 ------------
  t
 (1 row)

--- a/expected/arraybuffer.out
+++ b/expected/arraybuffer.out
@@ -1,0 +1,12 @@
+CREATE FUNCTION crash_test() RETURNS boolean
+LANGUAGE plv8 IMMUTABLE STRICT
+AS $$
+  var a = new ArrayBuffer(8);
+  return true;
+$$;
+SELECT crash_test();
+WARNING:  Allocating: 8
+ crash_test
+------------
+ t
+(1 row)

--- a/expected/arraybuffer.out
+++ b/expected/arraybuffer.out
@@ -10,3 +10,4 @@ WARNING:  Allocating: 8
 ------------
  t
 (1 row)
+

--- a/plv8.cc
+++ b/plv8.cc
@@ -140,8 +140,32 @@ class Plv8ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
     void* data = AllocateUninitialized(length);
     return data == NULL ? data : memset(data, 0, length);
   }
-  virtual void* AllocateUninitialized(size_t length) { return palloc(length); }
-  virtual void Free(void* data, size_t) { pfree(data); }
+  virtual void* AllocateUninitialized(size_t length) {
+			void *data = NULL;
+
+			PG_TRY();
+			{
+					data = palloc(length);
+			}
+			PG_CATCH();
+			{
+					throw pg_error();
+			}
+			PG_END_TRY();
+
+			return data;
+	}
+  virtual void Free(void* data, size_t) {
+			PG_TRY();
+			{
+					pfree(data);
+			}
+			PG_CATCH();
+			{
+					throw pg_error();
+			}
+			PG_END_TRY();
+	}
 };
 
 /*

--- a/sql/arraybuffer.sql
+++ b/sql/arraybuffer.sql
@@ -1,0 +1,8 @@
+CREATE FUNCTION crash_test() RETURNS boolean
+LANGUAGE plv8 IMMUTABLE STRICT
+AS $$
+  var a = new ArrayBuffer(8);
+  return true;
+$$;
+
+SELECT crash_test();


### PR DESCRIPTION
there is a crash due to a failed assertion when trying to use an ArrayBuffer (or anything that uses an ArrayBuffer internally).

the issue is due to `plv8` not providing an allocation handler.

this pull request adds an allocation handler which uses `palloc` and `pfree`, and sets it up before initialization.

there is not an additional regression test for the crash.

closes #126 

/cc @umitanuki