### PR TITLE
Upgrade to V8 4.4 - 4.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,8 @@ REQUIREMENT
 plv8 is tested with:
 
 - PG: version 9.3 and 9.4 (maybe older/newer are allowed)
-- V8: version 4.3.66
+- V8: version 4.4 to 4.10
 - g++: version 4.8.2
-
-It is also known to work with some older versions of gcc and v8.
 
 Also all tools that PostgreSQL and V8 require to be built are required if you
 are building those from source.

--- a/plv8.cc
+++ b/plv8.cc
@@ -1375,12 +1375,6 @@ FormatSPIStatus(int status) throw()
 	}
 }
 
-Handle<v8::Value>
-ThrowError(const char *message) throw()
-{
-	return plv8_isolate->ThrowException(Exception::Error(String::NewFromUtf8(plv8_isolate, message)));
-}
-
 static void
 GetGlobalContext(Persistent<Context>& global_context)
 {

--- a/plv8.cc
+++ b/plv8.cc
@@ -283,8 +283,6 @@ _PG_init(void)
 
 	EmitWarningsOnPlaceholders("plv8");
 
-	V8::SetArrayBufferAllocator(new Plv8ArrayBufferAllocator);
-
 	V8::InitializeICU();
 	Platform* platform = platform::CreateDefaultPlatform();
 	V8::InitializePlatform(platform);
@@ -292,7 +290,9 @@ _PG_init(void)
 	if (plv8_v8_flags != NULL) {
 	      V8::SetFlagsFromString(plv8_v8_flags, strlen(plv8_v8_flags));
 	}
-	plv8_isolate = Isolate::New();
+	Isolate::CreateParams params;
+	params.array_buffer_allocator = new Plv8ArrayBufferAllocator();
+	plv8_isolate = Isolate::New(params);
 	plv8_isolate->Enter();
 
 }

--- a/plv8.h
+++ b/plv8.h
@@ -67,6 +67,18 @@ public:
 	__attribute__((noreturn)) void rethrow() throw();
 };
 
+typedef enum plv8_external_array_type
+{
+	kExternalByteArray = 1,
+	kExternalUnsignedByteArray,
+	kExternalShortArray,
+	kExternalUnsignedShortArray,
+	kExternalIntArray,
+	kExternalUnsignedIntArray,
+	kExternalFloatArray,
+	kExternalDoubleArray
+} plv8_external_array_type;
+
 /*
  * When TYPCATEGORY_ARRAY, other fields are for element types.
  *
@@ -82,7 +94,7 @@ typedef struct plv8_type
 	char		category;
 	FmgrInfo	fn_input;
 	FmgrInfo	fn_output;
-	v8::ExternalArrayType ext_array;
+	plv8_external_array_type ext_array;
 } plv8_type;
 
 /*

--- a/plv8.h
+++ b/plv8.h
@@ -246,7 +246,6 @@ extern v8::Isolate* plv8_isolate;
 extern v8::Local<v8::Function> find_js_function(Oid fn_oid);
 extern v8::Local<v8::Function> find_js_function_by_name(const char *signature);
 extern const char *FormatSPIStatus(int status) throw();
-extern v8::Handle<v8::Value> ThrowError(const char *message) throw();
 extern plv8_type *get_plv8_type(PG_FUNCTION_ARGS, int argno);
 
 // plv8_type.cc

--- a/plv8_func.cc
+++ b/plv8_func.cc
@@ -354,7 +354,8 @@ plv8_Elog(const FunctionCallbackInfo<v8::Value>& args)
 		stream << CString(args[i]);
 	}
 
-	const char	   *message = stream.str().c_str();
+	std::string	string = stream.str();
+	const char	*message = string.c_str();
 
 	if (elevel != ERROR)
 	{


### PR DESCRIPTION
This commit makes plv8 API-compatible with V8 4.4 to 4.10.

The replacement of `v8::Object::GetIndexedPropertiesExternalArrayData()`
and `v8::Object::SetIndexedPropertiesToExternalArrayData()` with typed
arrays is the most notable change.

Compiling with `-std=c++11` is no longer optional; V8 requires it.

Caveat emptor: I suspect that the `make static` target is currently broken
unless special care is taken.  V8 compiles the snapshot to external .bin
files unless you build with `snapshot=off` or `GYPFLAGS+="-Dv8_use_external_startup_data=0"`.

Tests pass for me locally.