### PR TITLE
Travis fixes <9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,8 @@ before_script:
 
 
 env:
+  global:
+    - ARCH=x64
   matrix:
     - PGVERSION=9.5 v8=4.3
     - PGVERSION=9.5 v8=4.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,6 @@ before_script:
 
 
 env:
-  global:
-    - ARCH=x64
   matrix:
     - PGVERSION=9.5 v8=4.3
     - PGVERSION=9.5 v8=4.2

--- a/expected/plv8.out
+++ b/expected/plv8.out
@@ -714,7 +714,7 @@ SELECT f_attdrop(2);
  (2,10)
 (1 row)
 
-create table plv8test ( id serial, data json, sum integer, num integer);
+create table plv8test ( id numeric, data json, sum integer, num integer);
 insert into plv8test (data, sum, num) values ('{"a": 1, "b": 2}', 0, 0);
 insert into plv8test (data, sum, num) values ('{"a": 3, "b": 4}', 0, 0);
 insert into plv8test (data, sum, num) values ('{"a": 3, "b": 4}', 0, 0);

--- a/expected/plv8.out
+++ b/expected/plv8.out
@@ -714,7 +714,7 @@ SELECT f_attdrop(2);
  (2,10)
 (1 row)
 
-create table plv8test ( id serial primary key, data json, sum integer, num integer);
+create table plv8test ( id serial, data json, sum integer, num integer);
 insert into plv8test (data, sum, num) values ('{"a": 1, "b": 2}', 0, 0);
 insert into plv8test (data, sum, num) values ('{"a": 3, "b": 4}', 0, 0);
 insert into plv8test (data, sum, num) values ('{"a": 3, "b": 4}', 0, 0);

--- a/sql/plv8.sql
+++ b/sql/plv8.sql
@@ -426,7 +426,7 @@ ALTER TABLE t_attdrop DROP COLUMN b;
 SELECT f_attdrop(t.*) FROM t;
 SELECT f_attdrop(2);
 
-create table plv8test ( id serial, data json, sum integer, num integer);
+create table plv8test ( id numeric, data json, sum integer, num integer);
 insert into plv8test (data, sum, num) values ('{"a": 1, "b": 2}', 0, 0);
 insert into plv8test (data, sum, num) values ('{"a": 3, "b": 4}', 0, 0);
 insert into plv8test (data, sum, num) values ('{"a": 3, "b": 4}', 0, 0);

--- a/sql/plv8.sql
+++ b/sql/plv8.sql
@@ -426,7 +426,7 @@ ALTER TABLE t_attdrop DROP COLUMN b;
 SELECT f_attdrop(t.*) FROM t;
 SELECT f_attdrop(2);
 
-create table plv8test ( id serial primary key, data json, sum integer, num integer);
+create table plv8test ( id serial, data json, sum integer, num integer);
 insert into plv8test (data, sum, num) values ('{"a": 1, "b": 2}', 0, 0);
 insert into plv8test (data, sum, num) values ('{"a": 3, "b": 4}', 0, 0);
 insert into plv8test (data, sum, num) values ('{"a": 3, "b": 4}', 0, 0);


### PR DESCRIPTION
this fixes the NOTICE issues that show up the the tests in <9.3 versions of postgres - this removes the `serial` and `primary key` that were causing additional NOTICE lines to show up in the tests.

the tables were not being used in a way that needed a primary key, so this does not adversely affect the tests.