### PR TITLE
update travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ before_install:
   - sudo /etc/init.d/postgresql stop
   - sudo apt-get -y --purge remove postgresql libpq-dev libpq5 postgresql-client-common postgresql-common
   - sudo rm -rf /var/lib/postgresql
-  - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-  - sudo sh -c "echo deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main $PGVERSION >> /etc/apt/sources.list.d/postgresql.list"
+  - wget --no-check-certificate  --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+  - sudo sh -c "echo deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main $PGVERSION >> /etc/apt/sources.list.d/postgresql.list"
   - sudo apt-get update -qq
   - sudo apt-get -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::="--force-confnew" install postgresql-$PGVERSION postgresql-server-dev-$PGVERSION
   - sudo chmod 777 /etc/postgresql/$PGVERSION/main/pg_hba.conf
@@ -13,6 +13,7 @@ before_install:
   - sudo echo "host    all         all         127.0.0.1/32          trust" >> /etc/postgresql/$PGVERSION/main/pg_hba.conf
   - sudo echo "host    all         all         ::1/128               trust" >> /etc/postgresql/$PGVERSION/main/pg_hba.conf
   - sudo /etc/init.d/postgresql restart
+  - sudo apt-get install -y clang-3.5 llvm-3.5-dev libedit-dev
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update -qq
   - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
@@ -20,6 +21,9 @@ before_install:
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
 
 before_script:
+  - export V=1
+  - g++ -v
+  - gcc -v
   - pushd ..
   - git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
   - export PATH="$PATH":`pwd`/depot_tools
@@ -30,9 +34,9 @@ before_script:
   - git checkout $tag && gclient sync > /dev/null
   - git describe --always
   - make dependencies > /dev/null || true
-  - export CXX=g++
-  - export LD=g++
-  - make native library=shared -j8 werror=no snapshot=no
+  - export CXX=clang++
+  - export LD=clang++
+  - make native library=shared -j8 werror=no snapshot=no i18nsupport=off
   - sudo cp -rf include/* /usr/include
   - sudo cp -rf include /usr/include
   - sudo install -v --mode=0644 out/native/lib.target/* /usr/lib
@@ -46,22 +50,21 @@ env:
   matrix:
     - PGVERSION=9.5 v8=4.3
     - PGVERSION=9.5 v8=4.2
-    - PGVERSION=9.5 v8=4.1
     - PGVERSION=9.4 v8=4.3
     - PGVERSION=9.4 v8=4.2
-    - PGVERSION=9.4 v8=4.1
     - PGVERSION=9.3 v8=4.3
     - PGVERSION=9.3 v8=4.2
-    - PGVERSION=9.3 v8=4.1
     - PGVERSION=9.2 v8=4.3
     - PGVERSION=9.2 v8=4.2
-    - PGVERSION=9.2 v8=4.1
 
 
 language: cpp
 compiler:
-#  - clang
+  - clang
   - gcc
+
+sudo: required
+dist: trusty
 
 script:
   - make && sudo make install && make installcheck


### PR DESCRIPTION
this pull request updates the following in travis:

* removes older versions of v8 that are no longer shipping with the v8 source tree (4.1 and lower)
* asks to run on the new *trusty* platform
* compiles with both `clang++` and `g++`

this should fix tests enough to start to be able to trust travis builds and include a badge.