### PR TITLE
Remove #defines papering over C++ keywords

### DIFF
--- a/plv8.cc
+++ b/plv8.cc
@@ -9,12 +9,6 @@
 #include <new>
 
 extern "C" {
-#define delete		delete_
-#define namespace	namespace_
-#define	typeid		typeid_
-#define	typename	typename_
-#define	using		using_
-
 #if PG_VERSION_NUM >= 90300
 #include "access/htup_details.h"
 #endif
@@ -31,12 +25,6 @@ extern "C" {
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
 #include "utils/syscache.h"
-
-#undef delete
-#undef namespace
-#undef typeid
-#undef typename
-#undef using
 
 PG_MODULE_MAGIC;
 

--- a/plv8_func.cc
+++ b/plv8_func.cc
@@ -11,24 +11,12 @@
 #include <string>
 
 extern "C" {
-#define delete		delete_
-#define namespace	namespace_
-#define	typeid		typeid_
-#define	typename	typename_
-#define	using		using_
-
 #include "access/xact.h"
 #include "catalog/pg_type.h"
 #include "executor/spi.h"
 #include "parser/parse_type.h"
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
-
-#undef delete
-#undef namespace
-#undef typeid
-#undef typename
-#undef using
 } // extern "C"
 
 using namespace v8;

--- a/plv8_type.cc
+++ b/plv8_type.cc
@@ -8,12 +8,6 @@
 #include "plv8.h"
 
 extern "C" {
-#define delete		delete_
-#define namespace	namespace_
-#define	typeid		typeid_
-#define	typename	typename_
-#define	using		using_
-
 #if PG_VERSION_NUM >= 90300
 #include "access/htup_details.h"
 #endif
@@ -28,12 +22,6 @@ extern "C" {
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
 #include "utils/typcache.h"
-
-#undef delete
-#undef namespace
-#undef typeid
-#undef typename
-#undef using
 } // extern "C"
 
 //#define CHECK_INTEGER_OVERFLOW


### PR DESCRIPTION
These cause build failures with gcc-6.

This fixes the 1.4 branch for #184.