### PR TITLE
Update to newer v8

### DIFF
--- a/Makefile.v8
+++ b/Makefile.v8
@@ -7,12 +7,12 @@
 # structure in v8 which may be different from version to another, but user
 # can specify the v8 version by AUTOV8_VERSION, too.
 #-----------------------------------------------------------------------------#
-AUTOV8_VERSION = 5.1.281.14
+AUTOV8_VERSION = 5.4.500.43
 AUTOV8_DIR = build/v8-git-mirror-$(AUTOV8_VERSION)
 AUTOV8_OUT = build/v8-git-mirror-$(AUTOV8_VERSION)/out/native
 AUTOV8_DEPOT_TOOLS = build/depot_tools
 AUTOV8_LIB = $(AUTOV8_OUT)/libv8_snapshot.a
-AUTOV8_STATIC_LIBS = libv8_base.a libv8_nosnapshot.a libv8_libplatform.a libv8_libbase.a libicui18n.a libicuuc.a libicudata.a
+AUTOV8_STATIC_LIBS = libv8_base.a libv8_nosnapshot.a libv8_libplatform.a libv8_libbase.a libv8_libsampler.a libicui18n.a libicuuc.a
 
 export PATH := $(abspath $(AUTOV8_DEPOT_TOOLS)):$(PATH)
 
@@ -34,26 +34,26 @@ $(AUTOV8_DIR): $(AUTOV8_DEPOT_TOOLS)
 $(AUTOV8_LIB): $(AUTOV8_DIR)
 	env CXXFLAGS=-fPIC CFLAGS=-fPIC $(MAKE) -C build/v8-git-mirror-$(AUTOV8_VERSION) native
 	test -f $(AUTOV8_OUT)/libv8_base.a || \
-		ln -s $(abspath $(AUTOV8_OUT)/obj.target/tools/gyp/libv8_base.a) \
+		ln -s $(abspath $(AUTOV8_OUT)/obj.target/src/libv8_base.a) \
 			$(AUTOV8_OUT)/libv8_base.a
 	test -f $(AUTOV8_OUT)/libv8_nosnapshot.a || \
-		ln -s $(abspath $(AUTOV8_OUT)/obj.target/tools/gyp/libv8_nosnapshot.a) \
+		ln -s $(abspath $(AUTOV8_OUT)/obj.target/src/libv8_nosnapshot.a) \
 			$(AUTOV8_OUT)/libv8_nosnapshot.a
 	test -f $(AUTOV8_OUT)/libv8_libbase.a || \
-		ln -s $(abspath $(AUTOV8_OUT)/obj.target/tools/gyp/libv8_libbase.a) \
+		ln -s $(abspath $(AUTOV8_OUT)/obj.target/src/libv8_libbase.a) \
 			$(AUTOV8_OUT)/libv8_libbase.a
 	test -f $(AUTOV8_OUT)/libv8_libplatform.a || \
-		ln -s $(abspath $(AUTOV8_OUT)/obj.target/tools/gyp/libv8_libplatform.a) \
+		ln -s $(abspath $(AUTOV8_OUT)/obj.target/src/libv8_libplatform.a) \
 			$(AUTOV8_OUT)/libv8_libplatform.a
+	test -f $(AUTOV8_OUT)/libv8_libsampler.a || \
+		ln -s $(abspath $(AUTOV8_OUT)/obj.target/src/libv8_libsampler.a) \
+			$(AUTOV8_OUT)/libv8_libsampler.a
 	test -f $(AUTOV8_OUT)/libicui18n.a || \
 		ln -s $(abspath $(AUTOV8_OUT)/obj.target/third_party/icu/libicui18n.a) \
 			$(AUTOV8_OUT)/libicui18n.a
 	test -f $(AUTOV8_OUT)/libicuuc.a || \
 		ln -s $(abspath $(AUTOV8_OUT)/obj.target/third_party/icu/libicuuc.a) \
 			$(AUTOV8_OUT)/libicuuc.a
-	test -f $(AUTOV8_OUT)/libicudata.a || \
-		ln -s $(abspath $(AUTOV8_OUT)/obj.target/third_party/icu/libicudata.a) \
-			$(AUTOV8_OUT)/libicudata.a
 
 include Makefile
 


### PR DESCRIPTION
should fix GCC build issues, as v8 fixed upstream.

this also takes us to parity with nodejs 7.