### PR TITLE
Fixes #268 - Move DirectFunctionCall1() and other logic into PG_TRY/PG_CATCH.

### DIFF
--- a/expected/startup.out
+++ b/expected/startup.out
@@ -3,7 +3,7 @@ set plv8.start_proc = foo;
 do $$ plv8.elog(NOTICE, 'foo = ' + foo) $$ language plv8;
 WARNING:  failed to find js function function "foo" does not exist
 ERROR:  ReferenceError: foo is not defined
-CONTEXT:  undefined() LINE 1:  plv8.elog(NOTICE, 'foo = ' + foo)
+CONTEXT:  undefined() LINE 1:  plv8.elog(NOTICE, 'foo = ' + foo) 
 \c
 set plv8.start_proc = startup;
 do $$ plv8.elog(NOTICE, 'foo = ' + foo) $$ language plv8;

--- a/expected/startup.out
+++ b/expected/startup.out
@@ -1,7 +1,9 @@
 -- test startup failure
 set plv8.start_proc = foo;
 do $$ plv8.elog(NOTICE, 'foo = ' + foo) $$ language plv8;
-ERROR:  function "foo" does not exist
+WARNING:  failed to find js function function "foo" does not exist
+ERROR:  ReferenceError: foo is not defined
+CONTEXT:  undefined() LINE 1:  plv8.elog(NOTICE, 'foo = ' + foo)
 \c
 set plv8.start_proc = startup;
 do $$ plv8.elog(NOTICE, 'foo = ' + foo) $$ language plv8;

--- a/plv8.cc
+++ b/plv8.cc
@@ -1533,19 +1533,20 @@ GetGlobalContext(Persistent<Context>& global_context)
 			char perm[16];
 			strcpy(perm, "EXECUTE");
 			arg = charToText(perm);
-			Oid funcoid = DatumGetObjectId(DirectFunctionCall1(regprocin, CStringGetDatum(plv8_start_proc)));
-
-			MemSet(&fake_fcinfo, 0, sizeof(fake_fcinfo));
-			MemSet(&flinfo, 0, sizeof(flinfo));
-			fake_fcinfo.flinfo = &flinfo;
-			flinfo.fn_oid = InvalidOid;
-			flinfo.fn_mcxt = CurrentMemoryContext;
-			fake_fcinfo.nargs = 2;
-			fake_fcinfo.arg[0] = ObjectIdGetDatum(funcoid);
-			fake_fcinfo.arg[1] = CStringGetDatum(arg);
 
 			PG_TRY();
 			{
+				Oid funcoid = DatumGetObjectId(DirectFunctionCall1(regprocin, CStringGetDatum(plv8_start_proc)));
+
+				MemSet(&fake_fcinfo, 0, sizeof(fake_fcinfo));
+				MemSet(&flinfo, 0, sizeof(flinfo));
+				fake_fcinfo.flinfo = &flinfo;
+				flinfo.fn_oid = InvalidOid;
+				flinfo.fn_mcxt = CurrentMemoryContext;
+				fake_fcinfo.nargs = 2;
+				fake_fcinfo.arg[0] = ObjectIdGetDatum(funcoid);
+				fake_fcinfo.arg[1] = CStringGetDatum(arg);
+
 				Datum ret = has_function_privilege_id(&fake_fcinfo);
 
 				if (ret == 0) {


### PR DESCRIPTION
I know there were recent changes to this section of the code to address the security issue of the user having permissions to execute the `start_proc` function. I do not know if this change will cause issues with those:
https://github.com/plv8/plv8/commit/57db50d0dade7a840a8f325e5d0c89ef7fc71466
https://github.com/plv8/plv8/commit/c25ba0dd6de7e08e062606007e89f7c870974027
