### PR TITLE
Fix crash: Use cached isolate for V8 scopes in plv8_call_handler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ DATA = $(PLV8_DATA)
 DATA_built = plv8.sql
 REGRESS = init-extension plv8 plv8-errors scalar_args inline json startup_pre startup varparam json_conv \
 		  jsonb_conv window guc es6 arraybuffer composites currentresource startup_perms bytea find_function_perms \
-		  memory_limits reset show array_spread regression procedure
+		  memory_limits reset show array_spread regression procedure security_definer
 
 ifndef BIGINT_GRACEFUL
 	REGRESS += bigint

--- a/expected/security_definer.out
+++ b/expected/security_definer.out
@@ -1,0 +1,74 @@
+-- Regression test for https://github.com/plv8/plv8/issues/606
+-- Crash when a cached plv8 function is called from a different security context.
+CREATE FUNCTION sd_plv8_func() RETURNS int AS $$
+  var i = 1;
+  plv8.elog(NOTICE, "hi there");
+  return i;
+$$ LANGUAGE plv8;
+CREATE FUNCTION sd_plv8_wrapper() RETURNS void AS $$
+DECLARE
+  tmp int := 0;
+BEGIN
+  tmp := sd_plv8_func();
+END;
+$$ LANGUAGE plpgsql;
+CREATE PROCEDURE sd_secdef_proc() AS $$
+BEGIN
+  RAISE WARNING 'about to call plv8 via wrapper';
+  PERFORM sd_plv8_wrapper();
+  RAISE WARNING 'plv8 call succeeded';
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+CREATE ROLE sd_test_role LOGIN;
+GRANT USAGE ON SCHEMA public TO sd_test_role;
+GRANT EXECUTE ON FUNCTION sd_plv8_func() TO sd_test_role;
+GRANT EXECUTE ON FUNCTION sd_plv8_wrapper() TO sd_test_role;
+GRANT EXECUTE ON PROCEDURE sd_secdef_proc() TO sd_test_role;
+-- Cache the plv8 function under sd_test_role's isolate
+SET ROLE sd_test_role;
+SELECT sd_plv8_wrapper();
+NOTICE:  hi there
+ sd_plv8_wrapper 
+-----------------
+ 
+(1 row)
+
+-- The procedure is owned by the superuser, so GetPlv8Context() switches
+-- to a different isolate while fn_extra still holds sd_test_role's.
+-- On unfixed code this crashes the server.
+CALL sd_secdef_proc();
+WARNING:  about to call plv8 via wrapper
+NOTICE:  hi there
+WARNING:  plv8 call succeeded
+-- Preservation: plv8 still works after the cross-context call
+SELECT sd_plv8_wrapper();
+NOTICE:  hi there
+ sd_plv8_wrapper 
+-----------------
+ 
+(1 row)
+
+RESET ROLE;
+-- Reverse direction: superuser cache, then SET ROLE
+SELECT sd_plv8_func();
+NOTICE:  hi there
+ sd_plv8_func 
+--------------
+            1
+(1 row)
+
+SET ROLE sd_test_role;
+SELECT sd_plv8_func();
+NOTICE:  hi there
+ sd_plv8_func 
+--------------
+            1
+(1 row)
+
+RESET ROLE;
+-- Cleanup
+DROP PROCEDURE sd_secdef_proc();
+DROP FUNCTION sd_plv8_wrapper();
+DROP FUNCTION sd_plv8_func();
+REVOKE ALL ON SCHEMA public FROM sd_test_role;
+DROP ROLE sd_test_role;

--- a/plv8.cc
+++ b/plv8.cc
@@ -521,14 +521,19 @@ plv8_call_handler(PG_FUNCTION_ARGS)
 		plv8_proc *proc = (plv8_proc *) fcinfo->flinfo->fn_extra;
 		plv8_proc_cache *cache = proc->cache;
 
-		if (is_trigger)
-			return CallTrigger(fcinfo, proc->xenv);
-		else if (cache->retset)
-			return CallSRFunction(fcinfo, proc->xenv,
-						cache->nargs, proc->argtypes, &proc->rettype);
-		else
-			return CallFunction(fcinfo, proc->xenv,
-						cache->nargs, proc->argtypes, &proc->rettype);
+		{
+			Isolate::Scope	iscope(proc->xenv->isolate);
+			HandleScope		hscope(proc->xenv->isolate);
+
+			if (is_trigger)
+				return CallTrigger(fcinfo, proc->xenv);
+			else if (cache->retset)
+				return CallSRFunction(fcinfo, proc->xenv,
+							cache->nargs, proc->argtypes, &proc->rettype);
+			else
+				return CallFunction(fcinfo, proc->xenv,
+							cache->nargs, proc->argtypes, &proc->rettype);
+		}
 	}
 	catch (js_error& e)	{ e.rethrow(); }
 	catch (pg_error& e)	{ e.rethrow(); }

--- a/sql/security_definer.sql
+++ b/sql/security_definer.sql
@@ -1,0 +1,56 @@
+-- Regression test for https://github.com/plv8/plv8/issues/606
+-- Crash when a cached plv8 function is called from a different security context.
+
+CREATE FUNCTION sd_plv8_func() RETURNS int AS $$
+  var i = 1;
+  plv8.elog(NOTICE, "hi there");
+  return i;
+$$ LANGUAGE plv8;
+
+CREATE FUNCTION sd_plv8_wrapper() RETURNS void AS $$
+DECLARE
+  tmp int := 0;
+BEGIN
+  tmp := sd_plv8_func();
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE PROCEDURE sd_secdef_proc() AS $$
+BEGIN
+  RAISE WARNING 'about to call plv8 via wrapper';
+  PERFORM sd_plv8_wrapper();
+  RAISE WARNING 'plv8 call succeeded';
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE ROLE sd_test_role LOGIN;
+GRANT USAGE ON SCHEMA public TO sd_test_role;
+GRANT EXECUTE ON FUNCTION sd_plv8_func() TO sd_test_role;
+GRANT EXECUTE ON FUNCTION sd_plv8_wrapper() TO sd_test_role;
+GRANT EXECUTE ON PROCEDURE sd_secdef_proc() TO sd_test_role;
+
+-- Cache the plv8 function under sd_test_role's isolate
+SET ROLE sd_test_role;
+SELECT sd_plv8_wrapper();
+
+-- The procedure is owned by the superuser, so GetPlv8Context() switches
+-- to a different isolate while fn_extra still holds sd_test_role's.
+-- On unfixed code this crashes the server.
+CALL sd_secdef_proc();
+
+-- Preservation: plv8 still works after the cross-context call
+SELECT sd_plv8_wrapper();
+RESET ROLE;
+
+-- Reverse direction: superuser cache, then SET ROLE
+SELECT sd_plv8_func();
+SET ROLE sd_test_role;
+SELECT sd_plv8_func();
+RESET ROLE;
+
+-- Cleanup
+DROP PROCEDURE sd_secdef_proc();
+DROP FUNCTION sd_plv8_wrapper();
+DROP FUNCTION sd_plv8_func();
+REVOKE ALL ON SCHEMA public FROM sd_test_role;
+DROP ROLE sd_test_role;


### PR DESCRIPTION
Fixes #606

## Problem

When a plv8 function gets cached and then called through a `SECURITY DEFINER` routine (or after `SET ROLE`), the effective user changes. `GetPlv8Context()` resolves by effective user, so it returns a different isolate than the one the function was compiled under. The `Isolate::Scope`/`HandleScope` at the top of `plv8_call_handler` are set up with this new isolate, but the cached function still points to the old one, and this mismatch is causing server crashes.

## Fix

After cache retrieval, open an inner block scope with `Isolate::Scope` and `HandleScope` from `proc->xenv->isolate` before dispatching. This way V8 scopes always match the isolate the function was actually compiled under and added minimum runtime overhead cost.

## Reproduction (unfixed code)

Using the repro from #606:

```sql
CREATE FUNCTION jrt_plv8() RETURNS int AS $$
  var i = 1;
  plv8.elog(NOTICE, "hi there");
  return i;
$$ LANGUAGE plv8;

CREATE FUNCTION jrt_plv8wrapper() RETURNS void AS $$
DECLARE tmp int := 0;
BEGIN tmp := jrt_plv8(); END;
$$ LANGUAGE plpgsql;

CREATE PROCEDURE jrt_plpgsql() AS $$
BEGIN
  RAISE WARNING 'about to do something';
  PERFORM jrt_plv8wrapper();
  RAISE WARNING 'did something';
END;
$$ LANGUAGE plpgsql SECURITY DEFINER;

CREATE ROLE josh LOGIN;
-- grant execute on all three to josh

SET ROLE josh;
BEGIN;
SELECT jrt_plv8wrapper();   -- caches plv8 func under josh's isolate
CALL jrt_plpgsql();          -- SECURITY DEFINER switches to superuser context
SELECT jrt_plv8wrapper();
END;
```

Server crashes:
```
NOTICE:  hi there
 jrt_plv8wrapper
-----------------

(1 row)

WARNING:  about to do something
server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.
connection to server was lost
```

## After fix

Same repro, no crash:
```
NOTICE:  hi there
 jrt_plv8wrapper
-----------------

(1 row)

WARNING:  about to do something
NOTICE:  hi there
WARNING:  did something
CALL
NOTICE:  hi there
 jrt_plv8wrapper
-----------------

(1 row)

COMMIT
```

Full regression suite passes:
```
ok 1  - init-extension
ok 2  - plv8
...
ok 26 - procedure
ok 27 - security_definer
ok 28 - bigint
# All 28 tests passed.
```

## Changes

- `plv8.cc` — inner block scope with `Isolate::Scope`/`HandleScope` from `proc->xenv->isolate` around function dispatch
- `Makefile` — register `security_definer` in REGRESS
- `sql/security_definer.sql` + `expected/security_definer.out` — regression test

## Environment

- PLV8 3.2.4, PostgreSQL 17.7, macOS ARM64