### PR TITLE
Add PostgreSQL 19 support (fixes #608)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,7 +13,8 @@ jobs:
             REL_15_STABLE,
             REL_16_STABLE,
             REL_17_STABLE,
-            REL_18_BETA1
+            REL_18_STABLE,
+            REL_19_STABLE
           ]
     runs-on: ${{ matrix.os }}
 

--- a/plv8.cc
+++ b/plv8.cc
@@ -33,6 +33,9 @@ extern "C" {
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
 #include "utils/syscache.h"
+#if PG_VERSION_NUM >= 190000
+#include "utils/hsearch.h"
+#endif
 
 #include <signal.h>
 

--- a/plv8_type.cc
+++ b/plv8_type.cc
@@ -270,10 +270,17 @@ ConvertJsonb(JsonbContainer *in) {
 	return JsonbIterate(&it, container);
 }
 
+#if PG_VERSION_NUM >= 190000
+static JsonbValue *
+JsonbObjectFromObject(JsonbInState *pstate, Local<v8::Object> object);
+static JsonbValue *
+JsonbArrayFromArray(JsonbInState *pstate, Local<v8::Object> object);
+#else
 static JsonbValue *
 JsonbObjectFromObject(JsonbParseState **pstate, Local<v8::Object> object);
 static JsonbValue *
 JsonbArrayFromArray(JsonbParseState **pstate, Local<v8::Object> object);
+#endif
 
 static void LogType(Local<v8::Value> val, bool asError = true) {
 	if( val->IsUndefined() )
@@ -387,7 +394,11 @@ TimeAs8601 (double millis) {
 }
 
 static JsonbValue *
+#if PG_VERSION_NUM >= 190000
+JsonbFromValue(JsonbInState *pstate, Local<v8::Value> value, JsonbIteratorToken type) {
+#else
 JsonbFromValue(JsonbParseState **pstate, Local<v8::Value> value, JsonbIteratorToken type) {
+#endif
 	Isolate *isolate = Isolate::GetCurrent();
 	Local<Context>		context = isolate->GetCurrentContext();
 	JsonbValue val;
@@ -444,14 +455,28 @@ JsonbFromValue(JsonbParseState **pstate, Local<v8::Value> value, JsonbIteratorTo
 		}
 	}
 
+#if PG_VERSION_NUM >= 190000
+	pushJsonbValue(pstate, type, &val);
+	return pstate->result;
+#else
 	return pushJsonbValue(pstate, type, &val);
+#endif
 }
 
 static JsonbValue *
+#if PG_VERSION_NUM >= 190000
+JsonbArrayFromArray(JsonbInState *pstate, Local<v8::Object> object) {
+#else
 JsonbArrayFromArray(JsonbParseState **pstate, Local<v8::Object> object) {
+#endif
 	Isolate *isolate = Isolate::GetCurrent();
 	Local<Context>		context = isolate->GetCurrentContext();
+#if PG_VERSION_NUM >= 190000
+	pushJsonbValue(pstate, WJB_BEGIN_ARRAY, NULL);
+	JsonbValue *val = pstate->result;
+#else
 	JsonbValue *val = pushJsonbValue(pstate, WJB_BEGIN_ARRAY, NULL);
+#endif
 	Local<v8::Array> a = Local<v8::Array>::Cast(object);
 	for (size_t i = 0; i < a->Length(); i++) {
 		Local<v8::Value> o = a->Get(context, i).ToLocalChecked();
@@ -465,16 +490,30 @@ JsonbArrayFromArray(JsonbParseState **pstate, Local<v8::Object> object) {
 		}
 	}
 
+#if PG_VERSION_NUM >= 190000
+	pushJsonbValue(pstate, WJB_END_ARRAY, NULL);
+	val = pstate->result;
+#else
 	val = pushJsonbValue(pstate, WJB_END_ARRAY, NULL);
+#endif
 
 	return val;
 }
 
 static JsonbValue *
+#if PG_VERSION_NUM >= 190000
+JsonbObjectFromObject(JsonbInState *pstate, Local<v8::Object> object) {
+#else
 JsonbObjectFromObject(JsonbParseState **pstate, Local<v8::Object> object) {
+#endif
 	Isolate *isolate = Isolate::GetCurrent();
 	Local<Context>		context = isolate->GetCurrentContext();
+#if PG_VERSION_NUM >= 190000
+	pushJsonbValue(pstate, WJB_BEGIN_OBJECT, NULL);
+	JsonbValue *val = pstate->result;
+#else
 	JsonbValue *val = pushJsonbValue(pstate, WJB_BEGIN_OBJECT, NULL);
+#endif
 	Local<Array> arr = object->GetOwnPropertyNames(context).ToLocalChecked();
 
 	for (size_t i = 0; i < arr->Length(); i++) {
@@ -492,7 +531,12 @@ JsonbObjectFromObject(JsonbParseState **pstate, Local<v8::Object> object) {
 			val = JsonbFromValue(pstate, o, WJB_VALUE);
 		}
 	}
+#if PG_VERSION_NUM >= 190000
+	pushJsonbValue(pstate, WJB_END_OBJECT, NULL);
+	val = pstate->result;
+#else
 	val = pushJsonbValue(pstate, WJB_END_OBJECT, NULL);
+#endif
 	return val;
 }
 
@@ -508,7 +552,11 @@ ConvertObject(Local<v8::Object> object) {
 
 	MemoryContextSwitchTo(conversion_context);
 
+#if PG_VERSION_NUM >= 190000
+  JsonbInState pstate = {0};
+#else
   JsonbParseState *pstate = NULL;
+#endif
   JsonbValue *val;
 
 	if (object->IsArray()) {
@@ -518,7 +566,12 @@ ConvertObject(Local<v8::Object> object) {
 	} else {
 		pushJsonbValue(&pstate, WJB_BEGIN_ARRAY, NULL);
 		JsonbFromValue(&pstate, object, WJB_ELEM);
+#if PG_VERSION_NUM >= 190000
+		pushJsonbValue(&pstate, WJB_END_ARRAY, NULL);
+		val = pstate.result;
+#else
 		val = pushJsonbValue(&pstate, WJB_END_ARRAY, NULL);
+#endif
                 val->val.array.rawScalar = true;
 	}
 


### PR DESCRIPTION
## Summary

Adds PostgreSQL 19 support. Fixes #608.

PostgreSQL 19 changed the jsonb building API and dropped a transitive header include, which broke compilation of PLV8 on PG19:

1. `pushJsonbValue()` now takes a `JsonbInState *` (single pointer) and returns `void`, exposing the completed value via `pstate->result`, instead of taking `JsonbParseState **` and returning `JsonbValue *`.
2. `utils/hsearch.h` is no longer transitively included, so `HASHCTL`, `hash_create()`, `hash_search()`, `HASH_SEQ_STATUS`, etc. fail to resolve in `plv8.cc`.

Both are the exact errors reported in #608.

## Changes

- **`plv8_type.cc`** — `JsonbFromValue` / `JsonbArrayFromArray` / `JsonbObjectFromObject` / `ConvertObject` use `JsonbInState` and read `pstate->result` under `#if PG_VERSION_NUM >= 190000`.
- **`plv8.cc`** — include `utils/hsearch.h` on PG19+.
- **`.github/workflows/build_and_test.yml`** — add `REL_19_STABLE` to the build matrix, and bump `REL_18_BETA1` → `REL_18_STABLE` now that PG18 is released.

## Compatibility

Every change is gated behind `#if PG_VERSION_NUM >= 190000`, so PG 14/15/16/17/18 keep the existing code path unchanged.

## Testing

Verified the change against the PG19 `jsonb.h` header (confirmed the `JsonbInState.result` field and the new `void pushJsonbValue(JsonbInState *, ...)` signature). CI matrix now exercises `REL_19_STABLE`.
